### PR TITLE
Tags for party and raid member index

### DIFF
--- a/HydraUI/Elements/UnitFrames/Party.lua
+++ b/HydraUI/Elements/UnitFrames/Party.lua
@@ -631,6 +631,8 @@ local TestParty = function()
 	
 	if Testing then
 		if Header then
+			Header:SetAttribute("isTesting", false)
+
 			if (Header:GetAttribute("startingIndex") ~= -4) then
 				Header:SetAttribute("startingIndex", -4)
 			end
@@ -646,6 +648,8 @@ local TestParty = function()
 		Testing = false
 	else
 		if Header then
+			Header:SetAttribute("isTesting", true)
+
 			if (Header:GetAttribute("startingIndex") ~= -4) then
 				Header:SetAttribute("startingIndex", -4)
 			end

--- a/HydraUI/Elements/UnitFrames/Raid.lua
+++ b/HydraUI/Elements/UnitFrames/Raid.lua
@@ -484,6 +484,8 @@ local TestRaid = function()
 	
 	if Testing then
 		if Header then
+			Header:SetAttribute("isTesting", false)
+
 			if (Header:GetAttribute("startingIndex") ~= -24) then
 				Header:SetAttribute("startingIndex", -24)
 			end
@@ -499,6 +501,8 @@ local TestRaid = function()
 		Testing = false
 	else
 		if Header then
+			Header:SetAttribute("isTesting", true)
+
 			if (Header:GetAttribute("startingIndex") ~= -24) then
 				Header:SetAttribute("startingIndex", -24)
 			end

--- a/HydraUI/Elements/UnitFrames/UnitFrames.lua
+++ b/HydraUI/Elements/UnitFrames/UnitFrames.lua
@@ -35,6 +35,8 @@ local oUF = ns.oUF or oUF
 local Events = oUF.Tags.Events
 local Methods = oUF.Tags.Methods
 local Name, Duration, Expiration, Caster, SpellID, _
+local TestPartyIndex = 0
+local TestRaidIndex = 0
 
 Defaults["unitframes-only-player-debuffs"] = false
 Defaults["unitframes-show-player-buffs"] = true
@@ -512,6 +514,16 @@ end
 
 Events["PartyIndex"] = "GROUP_ROSTER_UPDATE PLAYER_ENTERING_WORLD"
 Methods["PartyIndex"] = function(unit)
+	local Header = _G["HydraUI Party"]
+
+	if Header and Header:GetAttribute("isTesting") then
+		if TestPartyIndex >= 5 then
+			TestPartyIndex = 0
+		end
+		TestPartyIndex = TestPartyIndex + 1
+		return TestPartyIndex
+	end
+
 	if unit == "player" then
 		return 1
 	end
@@ -522,9 +534,16 @@ end
 
 Events["RaidIndex"] = "GROUP_ROSTER_UPDATE PLAYER_ENTERING_WORLD"
 Methods["RaidIndex"] = function(unit)
-	if unit == "player" then
-		return 1
+	local Header = _G["HydraUI Raid"]
+
+	if Header and Header:GetAttribute("isTesting") then
+		if TestRaidIndex >= 25 then
+			TestRaidIndex = 0
+		end
+		TestRaidIndex = TestRaidIndex + 1
+		return TestRaidIndex
 	end
+
 	return UnitInRaid(unit)
 end
 
@@ -1019,6 +1038,7 @@ function UF:Load()
 		local Party = oUF:SpawnHeader("HydraUI Party", nil, "party,solo",
 			"initial-width", Settings["party-width"],
 			"initial-height", (Settings["party-health-height"] + Settings["party-power-height"] + 3),
+			"isTesting", false,
 			"showSolo", false,
 			"showPlayer", true,
 			"showParty", true,
@@ -1075,6 +1095,7 @@ function UF:Load()
 		local Raid = oUF:SpawnHeader("HydraUI Raid", nil, "raid,solo",
 			"initial-width", Settings["raid-width"],
 			"initial-height", (Settings["raid-health-height"] + Settings["raid-power-height"] + 3),
+			"isTesting", false,
 			"showSolo", false,
 			"showPlayer", true,
 			"showParty", false,

--- a/HydraUI/Elements/UnitFrames/UnitFrames.lua
+++ b/HydraUI/Elements/UnitFrames/UnitFrames.lua
@@ -510,6 +510,24 @@ Methods["LevelColor"] = function(unit)
 	return "|cFF" .. HydraUI:RGBToHex(Color.r, Color.g, Color.b)
 end
 
+Events["PartyIndex"] = "GROUP_ROSTER_UPDATE PLAYER_ENTERING_WORLD"
+Methods["PartyIndex"] = function(unit)
+	if unit == "player" then
+		return 1
+	end
+	if sub(unit, 1, 5) == "party" then
+		return tonumber(sub(unit, 6, 6)) + 1
+	end
+end
+
+Events["RaidIndex"] = "GROUP_ROSTER_UPDATE PLAYER_ENTERING_WORLD"
+Methods["RaidIndex"] = function(unit)
+	if unit == "player" then
+		return 1
+	end
+	return UnitInRaid(unit)
+end
+
 Events["RaidGroup"] = "GROUP_ROSTER_UPDATE PLAYER_ENTERING_WORLD"
 Methods["RaidGroup"] = function(unit)
 	local Name = UnitName(unit)


### PR DESCRIPTION
This adds two new text tags for unit frames, PartyIndex and RaidIndex, which correspond to the unit index in the party or raid. This is mostly a debug feature to be able to differentiate party frames from each other so that it is easier to test other features with the test mode.