### PR TITLE
Use anchor point instead of orientation for party unit frames

### DIFF
--- a/HydraUI/Elements/UnitFrames/Party.lua
+++ b/HydraUI/Elements/UnitFrames/Party.lua
@@ -607,23 +607,6 @@ local UpdatePartySpacing = function(value)
 	end
 end
 
-local UpdatePartyAnchor = function(value)
-	HydraUI.UnitFrames["party"]:SetAttribute("point", value)
-	C_UI.Reload()
-end
-
-local UpdateSetPartyOrientation = function(value)
-	if value == "VERTICAL" then
-		HydraUI.UnitFrames["party"]:SetAttribute("point", "TOP")
-		HydraUI.UnitFrames["party"]:SetAttribute("xoffset", 0)
-		HydraUI.UnitFrames["party"]:SetAttribute("yoffset", Settings["party-spacing"])
-	else
-		HydraUI.UnitFrames["party"]:SetAttribute("point", "LEFT")
-		HydraUI.UnitFrames["party"]:SetAttribute("xoffset", Settings["party-spacing"])
-		HydraUI.UnitFrames["party"]:SetAttribute("yoffset", 0)
-	end
-end
-
 local Testing = false
 
 local TestParty = function()

--- a/HydraUI/Elements/UnitFrames/Party.lua
+++ b/HydraUI/Elements/UnitFrames/Party.lua
@@ -611,6 +611,22 @@ local UpdatePartySpacing = function(value)
 			HydraUI.UnitFrames["party"]:SetAttribute("xOffset", 0)
 			HydraUI.UnitFrames["party"]:SetAttribute("yOffset", value)
 		end
+
+		if HydraUI.UnitFrames["party-pets"] then
+			if (Point == "LEFT") then
+				HydraUI.UnitFrames["party-pets"]:SetAttribute("xOffset", value)
+				HydraUI.UnitFrames["party-pets"]:SetAttribute("yOffset", 0)
+			elseif (Point == "RIGHT") then
+				HydraUI.UnitFrames["party-pets"]:SetAttribute("xOffset", - value)
+				HydraUI.UnitFrames["party-pets"]:SetAttribute("yOffset", 0)
+			elseif (Point == "TOP") then
+				HydraUI.UnitFrames["party-pets"]:SetAttribute("xOffset", 0)
+				HydraUI.UnitFrames["party-pets"]:SetAttribute("yOffset", - value)
+			elseif (Point == "BOTTOM") then
+				HydraUI.UnitFrames["party-pets"]:SetAttribute("xOffset", 0)
+				HydraUI.UnitFrames["party-pets"]:SetAttribute("yOffset", value)
+			end
+		end
 	end
 end
 

--- a/HydraUI/Elements/UnitFrames/Party.lua
+++ b/HydraUI/Elements/UnitFrames/Party.lua
@@ -20,7 +20,6 @@ Defaults["party-power-reverse"] = false
 Defaults["party-power-color"] = "POWER"
 Defaults["party-power-smooth"] = true
 Defaults["party-point"] = "LEFT"
-Defaults["party-orientation"] = "HORIZONTAL"
 Defaults["party-spacing"] = 2
 Defaults["party-font"] = "Roboto"
 Defaults["party-font-size"] = 12
@@ -158,7 +157,7 @@ HydraUI.StyleFuncs["party"] = function(self, unit)
 	Debuffs.CustomFilter = PartyDebuffFilter
 	Debuffs.showType = true
 	
-	if (Settings["party-orientation"] == "VERTICAL") then
+	if (Settings["party-point"] == "LEFT") or (Settings["party-point"] == "RIGHT") then
 		Debuffs:SetSize(24 * 3 + (2 * 2), 24 * 2 + 2)
 		Debuffs:SetPoint("TOPLEFT", self, "TOPRIGHT", 2, 0)
 		Debuffs.size = 24
@@ -596,14 +595,22 @@ local UpdatePartyShowRole = function(value)
 end
 
 local UpdatePartySpacing = function(value)
-	if (Settings["party-orientation"] == "VERTICAL") then
-		HydraUI.UnitFrames["party"]:SetAttribute("point", "BOTTOM")
-		HydraUI.UnitFrames["party"]:SetAttribute("xoffset", 0)
-		HydraUI.UnitFrames["party"]:SetAttribute("yoffset", value)
-	else
-		HydraUI.UnitFrames["party"]:SetAttribute("point", "LEFT")
-		HydraUI.UnitFrames["party"]:SetAttribute("xoffset", value)
-		HydraUI.UnitFrames["party"]:SetAttribute("yoffset", 0)
+	if HydraUI.UnitFrames["party"] then
+		local Point = HydraUI.UnitFrames["party"]:GetAttribute("point")
+
+		if (Point == "LEFT") then
+			HydraUI.UnitFrames["party"]:SetAttribute("xOffset", value)
+			HydraUI.UnitFrames["party"]:SetAttribute("yOffset", 0)
+		elseif (Point == "RIGHT") then
+			HydraUI.UnitFrames["party"]:SetAttribute("xOffset", - value)
+			HydraUI.UnitFrames["party"]:SetAttribute("yOffset", 0)
+		elseif (Point == "TOP") then
+			HydraUI.UnitFrames["party"]:SetAttribute("xOffset", 0)
+			HydraUI.UnitFrames["party"]:SetAttribute("yOffset", - value)
+		elseif (Point == "BOTTOM") then
+			HydraUI.UnitFrames["party"]:SetAttribute("xOffset", 0)
+			HydraUI.UnitFrames["party"]:SetAttribute("yOffset", value)
+		end
 	end
 end
 
@@ -692,7 +699,7 @@ GUI:AddWidgets(Language["General"], Language["Party"], function(left, right)
 	left:CreateSlider("party-out-of-range", Settings["party-out-of-range"], 0, 100, 5, Language["Out of Range"], Language["Set the opacity of party members out of your range"])
 	
 	left:CreateHeader(Language["Attributes"])
-	left:CreateDropdown("party-orientation", Settings["party-orientation"], {[Language["Horizontal"]] = "HORIZONTAL", [Language["Vertical"]] = "VERTICAL"}, Language["Set Orientation"], Language["Set the orientation of the party frames"], ReloadUI):RequiresReload(true)
+	left:CreateDropdown("party-point", Settings["party-point"], {[Language["Left"]] = "LEFT", [Language["Right"]] = "RIGHT", [Language["Top"]] = "TOP", [Language["Bottom"]] = "BOTTOM"}, Language["Anchor Point"], Language["Set the anchor point for the party frames"], ReloadUI):RequiresReload(true)
 	left:CreateSlider("party-spacing", Settings["party-spacing"], -10, 10, 1, Language["Set Spacing"], Language["Set the spacing of party units from eachother"], UpdatePartySpacing)
 	
 	right:CreateHeader(Language["Party Pets Size"])

--- a/HydraUI/Elements/UnitFrames/UnitFrames.lua
+++ b/HydraUI/Elements/UnitFrames/UnitFrames.lua
@@ -1077,14 +1077,21 @@ function UF:Load()
 	end
 	
 	if Settings["party-enable"] then
-		local Point = "LEFT"
-		local X = Settings["party-spacing"]
-		local Y = 0
+		local XOffset = 0
+		local YOffset = 0
 		
-		if (Settings["party-orientation"] == "VERTICAL") then
-			Point = "BOTTOM"
-			X = 0
-			Y = Settings["party-spacing"]
+		if (Settings["party-point"] == "LEFT") then
+			XOffset = Settings["party-spacing"]
+			YOffset = 0
+		elseif (Settings["party-point"] == "RIGHT") then
+			XOffset = - Settings["party-spacing"]
+			YOffset = 0
+		elseif (Settings["party-point"] == "TOP") then
+			XOffset = 0
+			YOffset = - Settings["party-spacing"]
+		elseif (Settings["party-point"] == "BOTTOM") then
+			XOffset = 0
+			YOffset = Settings["party-spacing"]
 		end
 		
 		local Party = oUF:SpawnHeader("HydraUI Party", nil, "party,solo",
@@ -1095,9 +1102,9 @@ function UF:Load()
 			"showPlayer", true,
 			"showParty", true,
 			"showRaid", false,
-			"xoffset", X,
-			"yOffset", Y,
-			"point", Point,
+			"xOffset", XOffset,
+			"yOffset", YOffset,
+			"point", Settings["party-point"],
 			"oUF-initialConfigFunction", [[
 				local Header = self:GetParent()
 				
@@ -1127,7 +1134,7 @@ function UF:Load()
 				"showPlayer", false,
 				"showParty", true,
 				"showRaid", false,
-				"xoffset", Settings["party-x-offset"],
+				"xOffset", Settings["party-x-offset"],
 				"yOffset", Settings["party-y-offset"],
 				"point", Settings["party-point"],
 				"oUF-initialConfigFunction", [[
@@ -1153,7 +1160,7 @@ function UF:Load()
 			"showParty", false,
 			"showRaid", true,
 			"point", Settings["raid-point"],
-			"xoffset", Settings["raid-x-offset"],
+			"xOffset", Settings["raid-x-offset"],
 			"yOffset", Settings["raid-y-offset"],
 			"maxColumns", Settings["raid-max-columns"],
 			"unitsPerColumn", Settings["raid-units-per-column"],

--- a/HydraUI/Elements/UnitFrames/UnitFrames.lua
+++ b/HydraUI/Elements/UnitFrames/UnitFrames.lua
@@ -1127,6 +1127,23 @@ function UF:Load()
 		HydraUI:CreateMover(self.PartyAnchor)
 		
 		if Settings["party-pets-enable"] then
+			local XOffset = 0
+			local YOffset = 0
+			
+			if (Settings["party-point"] == "LEFT") then
+				XOffset = Settings["party-spacing"]
+				YOffset = 0
+			elseif (Settings["party-point"] == "RIGHT") then
+				XOffset = - Settings["party-spacing"]
+				YOffset = 0
+			elseif (Settings["party-point"] == "TOP") then
+				XOffset = 0
+				YOffset = - Settings["party-spacing"]
+			elseif (Settings["party-point"] == "BOTTOM") then
+				XOffset = 0
+				YOffset = Settings["party-spacing"]
+			end
+
 			local PartyPet = oUF:SpawnHeader("HydraUI Party Pets", "SecureGroupPetHeaderTemplate", "party,solo",
 				"initial-width", Settings["party-pets-width"],
 				"initial-height", (Settings["party-pets-health-height"] + Settings["party-pets-power-height"] + 3),
@@ -1134,8 +1151,8 @@ function UF:Load()
 				"showPlayer", false,
 				"showParty", true,
 				"showRaid", false,
-				"xOffset", Settings["party-x-offset"],
-				"yOffset", Settings["party-y-offset"],
+				"xOffset", XOffset,
+				"yOffset", YOffset,
 				"point", Settings["party-point"],
 				"oUF-initialConfigFunction", [[
 					local Header = self:GetParent()
@@ -1144,9 +1161,20 @@ function UF:Load()
 					self:SetHeight(Header:GetAttribute("initial-height"))
 				]]
 			)
-			
-			PartyPet:SetPoint("BOTTOMLEFT", Party, "TOPLEFT", 0, 2)
+
+			if (Settings["party-point"] == "LEFT") then
+				PartyPet:SetPoint("TOPLEFT", Party, "BOTTOMLEFT", 0, - Settings["party-spacing"])
+			elseif (Settings["party-point"] == "RIGHT") then
+				PartyPet:SetPoint("TOPRIGHT", Party, "BOTTOMRIGHT", 0, - Settings["party-spacing"])
+			elseif (Settings["party-point"] == "TOP") then
+				PartyPet:SetPoint("TOPLEFT", Party, "BOTTOMLEFT", 0, - Settings["party-spacing"])
+			elseif (Settings["party-point"] == "BOTTOM") then
+				PartyPet:SetPoint("BOTTOMLEFT", Party, "TOPLEFT", 0, Settings["party-spacing"])
+			end
+
 			PartyPet:SetParent(HydraUI.UIParent)
+
+			HydraUI.UnitFrames["party-pets"] = PartyPet
 		end
 	end
 	


### PR DESCRIPTION
This pull request replaces the party orientation setting with a party anchor point. Additionally, it updates layout for party pet frames to be consistent with party frames.

This change aims at providing a more complete layout option for the party unit frames (4 directions instead of 2) and at  homogenizing party and raid settings. The anchor point setting already existed and was used by party pet frames, but it was not exposed. The raid settings also already use an anchor point.

Before:
![image](https://user-images.githubusercontent.com/3974249/128642526-4b941ccc-d5d8-45d9-aabc-3242c54394a1.png)
![image](https://user-images.githubusercontent.com/3974249/128642530-82ec6951-9ca9-4a15-9a3c-14af42f8a14a.png)

After:
![image](https://user-images.githubusercontent.com/3974249/128642537-84a69d38-c5db-4a52-b6a0-1dd4d3236a2d.png)
![image](https://user-images.githubusercontent.com/3974249/128642540-22e01600-fc46-4219-93b9-38e7616fc746.png)
